### PR TITLE
Add basic support to as65c for specifying the output .rel and .lis files.

### DIFF
--- a/Tools/as65c/SOURCE_CODE/as65c/as65c.py
+++ b/Tools/as65c/SOURCE_CODE/as65c/as65c.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
 	
 	parser.add_argument("-l", dest="LARG", action="store_true", help="unknown as of this time")
 	
+	parser.add_argument("-o", dest="relfile", type=str, help="Output rel file to produce")
 
 
 
@@ -82,6 +83,8 @@ if __name__ == "__main__":
 	if FILE[-4:].lower() == ".rel":
 		FILE = FILE[:-4] + ".asm"
 
+	relfile = ARGS.get("relfile", None)
+
 	print_verbose = False
 	if ARGS["p_verbose"] == True:
 		print_verbose = True
@@ -89,4 +92,4 @@ if __name__ == "__main__":
 
 
 	
-	assembler.assembleFile(FILE, optional_args, force_assemble=force_assembly, print_verbose=print_verbose)
+	assembler.assembleFile(FILE, optional_args, force_assemble=force_assembly, print_verbose=print_verbose, relfile=relfile)

--- a/Tools/as65c/SOURCE_CODE/as65c/assembler.py
+++ b/Tools/as65c/SOURCE_CODE/as65c/assembler.py
@@ -531,7 +531,7 @@ class ASM_FILE(object):
 
 
 
-def assembleFile(filename, ext_vars={}, force_assemble=False, check_hash=False, print_verbose=False):
+def assembleFile(filename, ext_vars={}, force_assemble=False, check_hash=False, print_verbose=False, relfile=None):
 
 	global EXTERNAL_SYMBOLS
 	global data_page
@@ -561,6 +561,9 @@ def assembleFile(filename, ext_vars={}, force_assemble=False, check_hash=False, 
 		#FILE_PATH = "/".join(filename.split("/")[:-1]) + "/"
 
 		FILE_PATH, FILE_NAME = get_file_attrs(filename)
+		if not relfile:
+			relfile = FILE_PATH + FILE_NAME.split(".")[0] + ".rel"
+
 
 		succeeded = False
 		hash_text = ""
@@ -574,7 +577,7 @@ def assembleFile(filename, ext_vars={}, force_assemble=False, check_hash=False, 
 
 		if not force_assemble:
 			try:
-				f = open(FILE_PATH + FILE_NAME.split(".")[0] + ".rel")
+				f = open(relfile)
 
 				f.close()
 			except:
@@ -4221,7 +4224,7 @@ def assembleFile(filename, ext_vars={}, force_assemble=False, check_hash=False, 
 			TEST_OFFS = 0
 			P_TEST_OFFS = 0
 			PREV_LINE = 0
-			with open(FILE_PATH + FILE_NAME.split(".")[0] + ".lis", "w") as LIS_FILE:
+			with open(relfile.rsplit(".", 1)[0] + ".lis", "w") as LIS_FILE:
 				for S in sections:
 					PREV_LINE = 0
 					L_IND = -1
@@ -4931,7 +4934,7 @@ def assembleFile(filename, ext_vars={}, force_assemble=False, check_hash=False, 
 
 		start = util.get_time()
 
-		with open(FILE_PATH + FILE_NAME.split(".")[0] + ".rel", "wb") as REL_FILE:
+		with open(relfile, "wb") as REL_FILE:
 			L = len(REL_DATA)
 			out_bytes = []
 			for ind in range(L):


### PR DESCRIPTION
This is a really quick hack which adds a `-o` command line option to optionally specify the output `.rel` file. The `.lis` file is then placed next to the `.rel`.

I needed this for my build system, which wants to do out-of-tree builds. It's had minimal testing but seems to work for me.